### PR TITLE
Fix(gh-actions): corrects errant api key variable

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
           GITHUB_PULL_BASE_SHA:  ${{ github.event.pull_request.base.sha }}
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITGUARDIAN_API_KEY: ${{ secrets.STHCODERS_GIT_GUARDIAN_API_KEY }}
             # Runs a single command using the runners shell
       - name: alert
         run: echo Scan is complete!


### PR DESCRIPTION
Edited the `gitguardian.yml` file to reflect the proper .env value of `STHCODERS_GIT_GUARDIAN_API_KEY`.